### PR TITLE
Add Android target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::os::unix::io::RawFd;
 
 use libc::c_int;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub use os::linux::*;
 
 #[cfg(target_os = "macos")]

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod linux;
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
This simply adds `target_os = "android"` to enable building on Android.
